### PR TITLE
Added waypoint marker, button highlighting, updated styling

### DIFF
--- a/screens/interiorScreen.js
+++ b/screens/interiorScreen.js
@@ -1,10 +1,16 @@
 import React, { useEffect, useState } from "react";
-import { StyleSheet, View, Image, Dimensions, Text, Pressable } from "react-native";
+import {
+  StyleSheet,
+  View,
+  Image,
+  Dimensions,
+  Text,
+  Pressable,
+} from "react-native";
 import { TouchableOpacity } from "react-native-gesture-handler";
 import ImageZoom from "react-native-image-pan-zoom";
 import { Icon } from "react-native-elements";
 import { useRoute } from "@react-navigation/native";
-
 
 const assets = require("../assets/assets.js");
 
@@ -39,11 +45,11 @@ export default function interiorScreen(navigation, route) {
     }
   };
   useEffect(() => {
-    console.log(currentFloor.substring(2, 3))
-    console.log(route.params.floor)
-    console.log(route.params.floor <= parseInt(currentFloor.substring(2, 3)))
-  })
-  console.log(route.params.xCoord - 64, route.params.yCoord - 32)
+    console.log(currentFloor.substring(2, 3));
+    console.log(route.params.floor);
+    console.log(route.params.floor <= parseInt(currentFloor.substring(2, 3)));
+  });
+  console.log(route.params.xCoord - 64, route.params.yCoord - 32);
   return (
     // Main interior screen
     <View style={styles.main}>
@@ -59,29 +65,21 @@ export default function interiorScreen(navigation, route) {
         centerOn={{ x: 0, y: 0, scale: 0.15, duration: 2 }}
       >
         <Image source={assets[buildingCode][currentFloor]} />
-        {/* Waypoint Marker: Not working */}
-        {/* <Icon
-          style={[
-            styles.waypoint,
-            {
-              // When this works, will have to add error handling for when it's not avaialbe
-              // marginTop: route.params.xCoord - 64,
-              // marginLeft: route.params.yCoord - 32,
-            }, // Waypoint locations offset by icon size
-          ]}
-          name="location-on"
-          size={64}
-          color="#F0CB02"
-        ></Icon> */}
-        {route.params.floor == currentFloor.substring(2, 3) &&
+
+        {/* Waypoint Marker*/}
+        {route.params.floor == currentFloor.substring(2, 3) && (
           <Pressable
             style={[
               styles.waypoint,
-              { top: route.params.yCoord - 256, left: route.params.xCoord - 256 / 2 }, // Waypoint locations offset by icon size
+              {
+                top: route.params.yCoord - 256,
+                left: route.params.xCoord - 256 / 2,
+              }, // Waypoint locations offset by icon size
             ]}
           >
             <Icon name="location-on" size={256} color="#F0CB02"></Icon>
-          </Pressable>}
+          </Pressable>
+        )}
       </ImageZoom>
 
       {/* Buttons for up/down floor */}
@@ -93,9 +91,16 @@ export default function interiorScreen(navigation, route) {
         {/* Up button */}
         {/* <View style={styles.button, route.params.floor <= parseInt(currentFloor.substring(2, 3)) ? styles.dark : styles.light}> */}
         <View style={styles.button}>
-
           <TouchableOpacity onPress={() => goUp()}>
-            <Icon size={32} color={route.params.floor <= parseInt(currentFloor.substring(2, 3)) ? "black" : "red"} name="keyboard-arrow-up" />
+            <Icon
+              size={32}
+              color={
+                route.params.floor <= parseInt(currentFloor.substring(2, 3))
+                  ? "black"
+                  : "red"
+              }
+              name="keyboard-arrow-up"
+            />
           </TouchableOpacity>
         </View>
 
@@ -103,7 +108,15 @@ export default function interiorScreen(navigation, route) {
         {/* <View style={styles.button, currentFloor >= currentFloor.substring(2, 3) ? styles.dark : styles.light}> */}
         <View style={styles.button}>
           <TouchableOpacity onPress={() => goDown()}>
-            <Icon size={32} color={route.params.floor >= parseInt(currentFloor.substring(2, 3)) ? "black" : "red"} name="keyboard-arrow-down" />
+            <Icon
+              size={32}
+              color={
+                route.params.floor >= parseInt(currentFloor.substring(2, 3))
+                  ? "black"
+                  : "red"
+              }
+              name="keyboard-arrow-down"
+            />
           </TouchableOpacity>
         </View>
       </View>
@@ -144,14 +157,14 @@ const styles = StyleSheet.create({
     backgroundColor: "#2D2D2D",
     top: 140,
     right: 120,
-    marginBottom: 10
+    marginBottom: 10,
   },
   chip: {
     // justify: "center",
     color: "white",
     padding: 14,
     paddingLeft: 20,
-    fontSize: 17
+    fontSize: 17,
   },
   dark: {
     borderWidth: 0,
@@ -163,8 +176,6 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     paddingBottom: 12,
     backgroundColor: "#665600",
-
-
   },
   light: {
     borderWidth: 0,
@@ -176,6 +187,5 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     paddingBottom: 12,
     backgroundColor: "#f0cb02",
-
-  }
+  },
 });

--- a/screens/interiorScreen.js
+++ b/screens/interiorScreen.js
@@ -1,14 +1,15 @@
-import React, { useState } from "react";
-import { StyleSheet, View, Image, Dimensions, Text } from "react-native";
+import React, { useEffect, useState } from "react";
+import { StyleSheet, View, Image, Dimensions, Text, Pressable } from "react-native";
 import { TouchableOpacity } from "react-native-gesture-handler";
 import ImageZoom from "react-native-image-pan-zoom";
 import { Icon } from "react-native-elements";
 import { useRoute } from "@react-navigation/native";
 
+
 const assets = require("../assets/assets.js");
 
 export default function interiorScreen(navigation, route) {
-  const [currentFloor, setCurrentFloor] = useState("SB0");
+  const [currentFloor, setCurrentFloor] = useState("SB1");
 
   // Route fix
   route = useRoute();
@@ -37,6 +38,12 @@ export default function interiorScreen(navigation, route) {
       setCurrentFloor(newFloor);
     }
   };
+  useEffect(() => {
+    console.log(currentFloor.substring(2, 3))
+    console.log(route.params.floor)
+    console.log(route.params.floor <= parseInt(currentFloor.substring(2, 3)))
+  })
+  console.log(route.params.xCoord - 64, route.params.yCoord - 32)
   return (
     // Main interior screen
     <View style={styles.main}>
@@ -53,7 +60,7 @@ export default function interiorScreen(navigation, route) {
       >
         <Image source={assets[buildingCode][currentFloor]} />
         {/* Waypoint Marker: Not working */}
-        <Icon
+        {/* <Icon
           style={[
             styles.waypoint,
             {
@@ -65,7 +72,16 @@ export default function interiorScreen(navigation, route) {
           name="location-on"
           size={64}
           color="#F0CB02"
-        ></Icon>
+        ></Icon> */}
+        {route.params.floor == currentFloor.substring(2, 3) &&
+          <Pressable
+            style={[
+              styles.waypoint,
+              { top: route.params.yCoord - 256, left: route.params.xCoord - 256 / 2 }, // Waypoint locations offset by icon size
+            ]}
+          >
+            <Icon name="location-on" size={256} color="#F0CB02"></Icon>
+          </Pressable>}
       </ImageZoom>
 
       {/* Buttons for up/down floor */}
@@ -75,16 +91,19 @@ export default function interiorScreen(navigation, route) {
         </View>
 
         {/* Up button */}
+        {/* <View style={styles.button, route.params.floor <= parseInt(currentFloor.substring(2, 3)) ? styles.dark : styles.light}> */}
         <View style={styles.button}>
+
           <TouchableOpacity onPress={() => goUp()}>
-            <Icon name="keyboard-arrow-up" />
+            <Icon size={32} color={route.params.floor <= parseInt(currentFloor.substring(2, 3)) ? "black" : "red"} name="keyboard-arrow-up" />
           </TouchableOpacity>
         </View>
 
         {/* Down button */}
+        {/* <View style={styles.button, currentFloor >= currentFloor.substring(2, 3) ? styles.dark : styles.light}> */}
         <View style={styles.button}>
           <TouchableOpacity onPress={() => goDown()}>
-            <Icon name="keyboard-arrow-down" />
+            <Icon size={32} color={route.params.floor >= parseInt(currentFloor.substring(2, 3)) ? "black" : "red"} name="keyboard-arrow-down" />
           </TouchableOpacity>
         </View>
       </View>
@@ -103,8 +122,8 @@ const styles = StyleSheet.create({
   },
   buttonContainer: {
     marginLeft: Dimensions.get("window").width * 0.8,
-    marginTop: Dimensions.get("window").height * 0.7,
-    justifyContent: "space-around",
+    marginTop: Dimensions.get("window").height * 0.65,
+    // justifyContent: "space-around",
     position: "absolute",
   },
   button: {
@@ -112,23 +131,51 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     borderRadius: 50,
     borderColor: "#f0cb02",
+    height: 50,
+    width: 50,
+    marginTop: 15,
+    paddingTop: 9,
+    paddingBottom: 4,
+  },
+  chipContainer: {
+    borderRadius: 50,
+    width: 100,
+    height: 50,
+    backgroundColor: "#2D2D2D",
+    top: 140,
+    right: 120,
+    marginBottom: 10
+  },
+  chip: {
+    // justify: "center",
+    color: "white",
+    padding: 14,
+    paddingLeft: 20,
+    fontSize: 17
+  },
+  dark: {
+    borderWidth: 0,
+    borderRadius: 50,
+    borderColor: "#f0cb02",
     maxWidth: 50,
     minWidth: 50,
     marginTop: 15,
-    paddingTop: 10,
-    paddingBottom: 15,
+    paddingTop: 12,
+    paddingBottom: 12,
+    backgroundColor: "#665600",
+
+
   },
-  chipContainer: {
-    borderRadius: 30,
-    width: 80,
-    height: 32,
-    backgroundColor: "#2D2D2D",
-    top: 122,
-    right: 100,
-  },
-  chip: {
-    color: "white",
-    padding: 5,
-    paddingLeft: 15,
-  },
+  light: {
+    borderWidth: 0,
+    borderRadius: 50,
+    borderColor: "#f0cb02",
+    maxWidth: 50,
+    minWidth: 50,
+    marginTop: 15,
+    paddingTop: 12,
+    paddingBottom: 12,
+    backgroundColor: "#f0cb02",
+
+  }
 });

--- a/screens/loginScreen.js
+++ b/screens/loginScreen.js
@@ -21,19 +21,19 @@ import { TouchableHighlight } from "react-native-gesture-handler";
 export default function LoginScreen({ navigation }) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  checkCredentials = () => {
+  const checkCredentials = () => {
     let re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|([a-z]+[0-9]+)@calvin.edu)$/;
     // .endsWith makes sure it's a calivn email
     if (
       (re.test(username) &&
         password != "" &&
         username.endsWith("@calvin.edu")) ||
-        username.endsWith("@students.calvin.edu")
+      username.endsWith("@students.calvin.edu")
     ) {
       navigation.navigate("Map");
     } else {
       Alert.alert("Error", "Invalid credentials", [
-        { text: "Okay", onPress: () => {} },
+        { text: "Okay", onPress: () => { } },
       ]);
     }
   };
@@ -83,12 +83,12 @@ export default function LoginScreen({ navigation }) {
 
         {/* guest login */}
         <View style={styles.guest}>
-          <TouchableOpacity style={styles.guestbutton}>
+          <TouchableOpacity style={styles.guestbutton} onPress={() => navigation.navigate("Map")}>
             <Text style={styles.guesttext}>Continue as guest</Text>
           </TouchableOpacity>
         </View>
       </View>
-    </ScrollView>
+    </ScrollView >
   );
 }
 

--- a/screens/mapScreen.js
+++ b/screens/mapScreen.js
@@ -175,7 +175,8 @@ export default function mapScreen({ navigation }) {
         debug && console.log(pointY);
       } else {
         setLoading(false);
-        Alert.alert("Out of bounds.");
+        console.log("Out of bounds!!!");
+        // Alert.alert("Out of bounds.");
       }
     }
   }, [pos]);

--- a/styles/style.css
+++ b/styles/style.css
@@ -1,0 +1,3 @@
+.dark {
+  background-color: '#a38a00';
+}


### PR DESCRIPTION
This is an update to what was added in PR #23 which revamped the interior screen as well as a few other changes. What I have done:

* Found a way to make the waypoint show up
* Did some tweaks to the styling of the buttons and chip near the bottom 
(Including: enlarging button icons, enlarging the floor chip and text size, attempting to align the floor chip and bottom button)
* Added a highlight to the up and down buttons indicating which way to go to find the floor you are looking for
(Note: I am not completely happy with how this looks, we should discuss how to indicate in which direction the goal floor is.)
* You can now click on "continue as guest" in the login screen and it will put you through to the map screen (for development purposes)


Things that still need to be done with the interior screen:
* Cleaning up how the layout is being done
(I haven't tested the layout on different sized devices and it is quite possible it will break or look off when the screen size is different)
* Find a better way to indicate which way the floor you want is
* Initial floor when loading into the interior screen (building independent)